### PR TITLE
Upgrade from .NET 8 to .NET 10 LTS

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
         
     - name: Restore dependencies
       run: dotnet restore

--- a/CRMWorkflowToSentry/CRMWorkflowToSentry.csproj
+++ b/CRMWorkflowToSentry/CRMWorkflowToSentry.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>CRMWorkflowToSentry</RootNamespace>
     <AssemblyName>CRMWorkflowToSentry</AssemblyName>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Bumps TargetFramework net8.0 → net10.0 and CI dotnet-version 8.0.x → 10.0.x.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
